### PR TITLE
Add an option to override default buttons

### DIFF
--- a/lib/tool-bar-almighty.coffee
+++ b/lib/tool-bar-almighty.coffee
@@ -11,6 +11,12 @@ toolBarAlmighty.config =
     description: 'A cson or json file path containing extra entries. Path should be relative to the Atom\'s configuration directory (.atom). For details read tool-bar-almighty\'s README.md file'
     type: 'string'
     default: ''
+  override:
+    title: 'Override default entries'
+    description: 'If checked, default `entries.coffee` buttons are replaced with the settings above\n, otherwise the default settings is extended with the file above.'
+    type: 'boolean'
+    default: false
+
 
 toolBarAlmighty.deactivate = ->
   @toolBar?.removeItems()
@@ -19,8 +25,10 @@ toolBarAlmighty.consumeToolBar = (toolBar) ->
   @toolBar = toolBar 'tool-bar-almighty'
 
   customEntries = utils.getCustomEntries(atom.config.get(pkg.name + '.custom'))
+  overrideDefault = atom.config.get(pkg.name + '.override')
+
   if customEntries
-    entries = entries.concat(customEntries)
+    entries = if overrideDefault then customEntries else entries.concat(customEntries)
 
   for entry in entries
     utils.parseEntry(@toolBar, entry)


### PR DESCRIPTION
Hello, I was wondering if you'd be interested in an option that allows the user to either extend the default buttons or completely replace it with its own set of buttons.
