### PR TITLE
Add "New" button to the toolbar as a way to create a new file.

### DIFF
--- a/lib/entries.coffee
+++ b/lib/entries.coffee
@@ -1,5 +1,12 @@
 module.exports = [
   {
+    type: 'button',
+    tooltip: 'New File',
+    callback: 'application:new-file',
+    icon: 'plus',
+    iconset: 'ion'
+  },    
+  {
     type: 'button'
     tooltip: 'Open File'
     callback: 'application:open-file'


### PR DESCRIPTION
Slightly embarrassing, but I _just_ realized this has been debated before: https://github.com/varemenos/atom-toolbar-almighty/issues/7

However, I added this code onto my machine and have really grown to like it.  I often have to switch between platforms and always forget the proper keyboard shortcut.  So I've grown to like having something this simple to fall back on.



