### PR TITLE
Update fold / unfold all icons for Font Awesome 5.4.2

### DIFF
--- a/lib/entries.coffee
+++ b/lib/entries.coffee
@@ -114,14 +114,14 @@ module.exports = [
     type: 'button'
     tooltip: 'Fold all'
     callback: 'editor:fold-all'
-    icon: 'level-up'
+    icon: 'level-up-alt'
     iconset: 'fa'
   },
   {
     type: 'button'
     tooltip: 'Unfold all'
     callback: 'editor:unfold-all'
-    icon: 'level-down'
+    icon: 'level-down-alt'
     iconset: 'fa'
   },
   {


### PR DESCRIPTION
Tool-Bar now ships with Font Awesome 5.4.2, which breaks the fold / unfold all icons.